### PR TITLE
upd : default.html.jade < doctype must be html, fixes #1

### DIFF
--- a/src/layouts/default.html.jade
+++ b/src/layouts/default.html.jade
@@ -19,7 +19,7 @@
 - styles.add(["/styles/style.css"])
 - scripts.add(["/scripts/script.js"])
 
-doctype 5
+doctype html
 html(lang="en")
   head
 


### PR DESCRIPTION
doctype 5 is forbidden now:

```
error: Something went wrong while rendering: /home/almereyda/Fundgrube/github.com/elevate-festival/dspace-menu/src/documents/index.html.jade
The error follows:

Error: /home/almereyda/Fundgrube/github.com/elevate-festival/dspace-menu/src/layouts/default.html.jade:22
    20| - scripts.add(["/scripts/script.js"])
    21|
  > 22| doctype 5
    23| html(lang="en")
    24|   head
    25|

`doctype 5` is deprecated, you must now use `doctype html`
  at Object.Lexer.doctype (/home/almereyda/Fundgrube/github.com/elevate-festival/dspace-menu/node_modules/docpad-plugin-jade/node_modules/jade/lib/lexer.js:256:13)
```
